### PR TITLE
feat(genz): switch registration to new Google Sheet for phase 2

### DIFF
--- a/app/api/genz/register/route.ts
+++ b/app/api/genz/register/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 
 const GOOGLE_SCRIPT_URL = process.env.GOOGLE_SHEET_GENZ_WEBHOOK_URL
-const SPREADSHEET_ID = '1VBEHJUowb28kMaMeVHA8dEE2ttE8fq0GT7CH2XcHH-0'
+const SPREADSHEET_ID = '1_QRDprrHTucjoH_eBaDj6YcpoCy31-phbHGihIpZakU'
 const ALLOWED_ORIGINS = new Set([
   'http://localhost:3000',
   'http://localhost:3001',


### PR DESCRIPTION
Updates the Gen Z registration API route to point to the new Google Sheet and webhook URL for phase 2 (45% OFF).\n\n- Updated `SPREADSHEET_ID` to `1_QRDprrHTucjoH_eBaDj6YcpoCy31-phbHGihIpZakU`\n- Updated `GOOGLE_SHEET_GENZ_WEBHOOK_URL` env var in Vercel